### PR TITLE
RFC: storing-trust-pkcs11: Add whitelisted set

### DIFF
--- a/specs/storing-trust-model.xml
+++ b/specs/storing-trust-model.xml
@@ -47,8 +47,8 @@
 			not represented. Instead this is a common base of information to share, which
 			augmented by other application specific information.</para>
 
-		<para>This document currently limits itself to treatment of anchors and blacklisted
-			certificates. Later companion documents will deal with pinned keys and shared
+		<para>This document currently limits itself to treatment of anchors, blacklisted
+			certificates, and optional whitelisted certificates. Later companion documents will deal with shared
 			state/storage needed by alternative trust validation implementations.</para>
 	</sect2>
 </sect1>
@@ -173,6 +173,26 @@
 		such as OCSP and OCSP Stapling.</para>
 
 	<para>On Linux there has been no standard way to represent blacklists. Various
+		crypto libraries have various means of representing them, and
+		<link linkend="storing-trust-existing">we examine them elsewhere</link>.
+		This document wishes to define a such a standard.</para>
+</sect2>
+
+<sect2 id="concept-whitelist">
+	<title>About Whitelisting and Certificate Pinning</title>
+
+	<para>A whitelisted key or certificate is one that should be accepted outright
+		when it is encountered in a validation algorithm.</para>
+
+	<para>When dealing with locally installed anchors, it is often required that
+		an end entity certificate needs to be explicitly trusted for a given
+		purpose or policy. The concept of whitelists complements anchors to
+		support such use-cases.</para>
+
+	<para>Whitelists always have precedence over blacklists and distributed by system
+		administrators or local users.</para>
+
+	<para>On Linux there has been no standard way to represent whitelists. Various
 		crypto libraries have various means of representing them, and
 		<link linkend="storing-trust-existing">we examine them elsewhere</link>.
 		This document wishes to define a such a standard.</para>

--- a/specs/storing-trust-pkcs11.xml
+++ b/specs/storing-trust-pkcs11.xml
@@ -219,6 +219,55 @@
 		the <literal>CKA_CLASS</literal> attribute.</para>
 </simplesect>
 
+<simplesect id="pkcs11-whitelist">
+	<title>Set: Whitelist</title>
+
+	<para>We define a new boolean attribute CKA_X_WHITELISTED to indicate
+		whitelist status.</para>
+
+	<para>The following attribute is set on items that are part of the
+		whitelist set:</para>
+
+	<variablelist>
+		<varlistentry>
+			<term><literal>CKA_X_WHITELISTED</literal></term>
+			<listitem><para>Value: <literal>CK_TRUE</literal></para></listitem>
+		</varlistentry>
+	</variablelist>
+
+	<para>Items in the whitelist set contain the following fields:</para>
+
+	<variablelist>
+		<varlistentry>
+			<term><literal>CKA_PUBLIC_KEY_INFO</literal></term>
+			<listitem><para>The public key of the anchor. A DER encoded
+			SubjectPublicKeyInfo sequence as defined in X.509. When this
+			value is not present, set to a zero length value.</para></listitem>
+		</varlistentry>
+		<varlistentry>
+			<term><literal>CKA_ISSUER</literal></term>
+			<listitem><para>The DN of the issuer. Contents as defined in
+			PKCS#11: a DER encoded Name sequence defined in X.509.</para></listitem>
+		</varlistentry>
+		<varlistentry>
+			<term><literal>CKA_SERIAL_NUMBER</literal></term>
+			<listitem><para>The serial number assigned by the issuer. Contents
+			as defined in PKCS#11: a DER encoded Name sequence defined in
+			X.509.</para></listitem>
+		</varlistentry>
+		<varlistentry>
+			<term><literal>CKA_CLASS</literal></term>
+			<listitem><para>Set to <literal>CKO_CERTIFICATE</literal> when the
+			<literal>CKA_ISSUER</literal> and <literal>CKA_SERIAL_NUMBER</literal> are
+			present. Otherwise may be set to either <literal>CKO_PUBLIC_KEY</literal>
+			or <literal>CKO_CERTIFICATE</literal> as appropriate.</para></listitem>
+		</varlistentry>
+	</variablelist>
+
+	<para>Other standard PKCS#11 fields should be present on the objects as per
+		the <literal>CKA_CLASS</literal> attribute.</para>
+</simplesect>
+
 <simplesect>
 	<title>Set: Attached Extensions</title>
 
@@ -274,6 +323,7 @@
 <![CDATA[
 #define CKO_X_CERTIFICATE_EXTENSION   0xd84447c8UL
 #define CKA_X_DISTRUSTED              0xd8444764UL
+#define CKA_X_WHITELISTED             0xd8444765UL
 
 /* The following definition comes from PKCS#11 2.40
 #define CKA_PUBLIC_KEY_INFO           0x00000129UL


### PR DESCRIPTION
trust-policy currently doesn't define a way to mark a certificate trusted for certain purposes, while that was possible with trust-assertions and exposed through the GCR library.  This adds a
minimal support for pinned certificates through a new PKCS#11 attribute `CKA_X_WHITELISTED`.

See https://gitlab.gnome.org/GNOME/gcr/issues/6 for the rationale.